### PR TITLE
refactor: add dry-mode to test the tool quickly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 reports/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WIP new deployment tool
 
 # Development
 
-`GITHUB_REPOSITORY="levibostian/Wendy-iOS" GITHUB_TOKEN="XXX" deno run --allow-all deploy.ts`
+`GITHUB_REF="refs/heads/main" GITHUB_REPOSITORY="levibostian/Wendy-iOS" DRY_RUN=true INPUT_GITHUB_TOKEN="XXX" deno run --allow-all deploy.ts`
 
 # Tests
 

--- a/deploy.ts
+++ b/deploy.ts
@@ -20,6 +20,12 @@ const githubRef = Deno.env.get("GITHUB_REF")!;
 log.debug(`GITHUB_REF: ${githubRef}`);
 const currentBranch = githubRef.replace("refs/heads/", "");
 log.debug(`name of current git branch: ${currentBranch}`);
+const isDryRunMode = Deno.env.get("DRY_RUN") === "true"; 
+if (isDryRunMode) {
+  log.warning(
+    `Dry run mode is enabled. This means that I will not actually deploy anything. I will only print out what I would do if I were to deploy.`,
+  );
+}
 
 // example value for GITHUB_REPOSITORY: "denoland/deno"
 const githubRepositoryFromEnvironment = Deno.env.get("GITHUB_REPOSITORY")!;
@@ -90,6 +96,12 @@ log.message(
 );
 
 log.notice(`Creating a new release on GitHub for the new version...`);
+if (isDryRunMode) {
+  log.warning(
+    `Dry run mode is enabled. I would have created a new release on GitHub with the new version: ${nextReleaseVersion}`,
+  );
+  Deno.exit(0);
+}
 await createGitHubRelease({
   owner,
   repo,


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

During development, I found that it was taking a lot of work to test the tool out. Create a temporary github repo, setup the action, create branches, etc... Takes quite a long time! And when you find a bug, debugging can take an extra long time since the tool runs on the CI and not your local dev machine. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

To make testing faster, this is adding a dry-mode which is a read-only mode. This mode is internal for now and we may or may not publicly document it. 

The idea is, before you test the tool in a real github repo, try it in dry-mode on your development machine first. If it seems to run correctly, then test it on the real CI server. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

See instructions in README to run in dry-mode. I ran dry-mode against some of my github repos and it worked as expected. The tool showed bugs that it has, but at least dry-run ran as it should. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->