### PR TITLE
refactor: run CLI outside docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM denoland/deno:distroless
-
-COPY . /action
-WORKDIR /action
-
-ENTRYPOINT ["deno", "run", "--allow-all"]
-CMD ["/action/deploy.ts"]

--- a/action.yml
+++ b/action.yml
@@ -21,3 +21,4 @@ runs:
       # Deno's runtime permissions are a great feature. It would be nice to take advantage of it, however, it may not be possible with future features like running plugins. 
       run: deno run --allow-env=GITHUB_REF,DRY_RUN,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN --allow-net="api.github.com" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/deploy.ts
       shell: bash 
+      env: ${{ toJson(env) }} # pass all environment vars 

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,20 @@
 name: 'New deployment tool'
 description: 'Deploy your project with ease'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'
 
 inputs:
   github_token:
     description: 'GITHUB_TOKEN or a repo scoped PAT.'
     default: ${{ github.token }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Deno runtime to run the CLI
+      uses: denoland/setup-deno@v1
+      with:
+        deno-version: v1.x
+
+    - name: Run deployment tool 
+      # Deno's runtime permissions are a great feature. It would be nice to take advantage of it, however, it may not be possible with future features like running plugins. 
+      run: deno run --allow-env=GITHUB_REF,DRY_RUN,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN --allow-net="api.github.com" deploy.ts
+      shell: bash 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,4 @@ runs:
       run: deno run --allow-env=GITHUB_REF,DRY_RUN,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN --allow-net="api.github.com" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/deploy.ts
       shell: bash 
       env:
-        GITHUB_REF: ${{ env.GITHUB_REF }}
-        DRY_RUN: false         
-        GITHUB_REPOSITORY: ${{ env.GITHUB_REPOSITORY }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN or a repo scoped PAT.'
     default: ${{ github.token }}
+  version:
+    description: 'Version of the CLI to use.'
+    default: 'main' # using branch name for now for easier deployments 
 
 runs:
   using: "composite"
@@ -16,5 +19,5 @@ runs:
 
     - name: Run deployment tool 
       # Deno's runtime permissions are a great feature. It would be nice to take advantage of it, however, it may not be possible with future features like running plugins. 
-      run: deno run --allow-env=GITHUB_REF,DRY_RUN,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN --allow-net="api.github.com" deploy.ts
+      run: deno run --allow-env=GITHUB_REF,DRY_RUN,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN --allow-net="api.github.com" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/deploy.ts
       shell: bash 

--- a/action.yml
+++ b/action.yml
@@ -21,4 +21,8 @@ runs:
       # Deno's runtime permissions are a great feature. It would be nice to take advantage of it, however, it may not be possible with future features like running plugins. 
       run: deno run --allow-env=GITHUB_REF,DRY_RUN,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN --allow-net="api.github.com" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/deploy.ts
       shell: bash 
-      env: ${{ toJson(env) }} # pass all environment vars 
+      env:
+        GITHUB_REF: ${{ env.GITHUB_REF }}
+        DRY_RUN: false         
+        GITHUB_REPOSITORY: ${{ env.GITHUB_REPOSITORY }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

The next feature to add to the tool is being able to run scripts provided by the user to execute to deploy their code. In order for us to be able to run scripts, we must run the CLI outside of a Docker container. Running scripts inside a Docker container will simply not work or be too complex to work as we intend. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Since this tool is written in Deno, I evaluated a few options...


1. (What I chose) Change the action to be a composite action that installs Deno runtime and then executes the deploy CLI script via Deno CLI. 

pros: easy to maintain, simple to understand, get the deno features like runtime permissions, pretty fast compared to maybe running binaries, run CLI the way deno intends which gives us all deno features if we need them, if there is a bug with tool the stacktrace is accurate 
cons: does this make the tool more complex by requiring that we do runtime permissions? 

<details>
<summary>List of other options not chosen</summary>
<br>
2. Compile a binary of this CLI tool and then have the action run the binary

pros: for the end developer, it's just running a CLI. easy for them. no runtime permissions to worry about
cons: harder to maintain since I need to create and release binaries. when bugs occur for users, is it harder for them to report issues since the stacktrace might be weird? 

4. Generate [npm module of this tool](https://deno.com/learn/modules), upload to npm, and then simply run `npx new-deployment-tool` in the github action. 
pros: pretty simple to maintain. node installed on github actions by default. running npx is simple.
cons: more work during deployments but minimal. dont get runtime permissions. maybe the tool is buggy and it will limit the deno code I could run

5. Upload this tool to jsr > in github action, use `npx jsr install new-deployment-tool` > `npx new-deployment-tool`
pros: just upload deno code to jsr and it does the work for me.
cons: runtime permissions work or break? not sure if jsr is meant to work well for CLI tools but packages.
</details>

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

Ran this branch on a test repository. It ran a deployment as expected. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->