### PR TITLE
ci: print stack of PRs when create a new PR

### DIFF
--- a/.github/workflows/pr-stacks.yml
+++ b/.github/workflows/pr-stacks.yml
@@ -1,0 +1,15 @@
+on: [pull_request]
+
+jobs:
+  print-pr-stack:
+    name: Display the PR stack
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # Required for PR comments
+    steps:
+      - uses: actions/checkout@v4
+      - uses: git-town/action@v1
+        with: 
+          main-branch: 'main'
+          perennial-regex: '^feat/.*$'


### PR DESCRIPTION
## Related GitHub Issues

<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem

<!-- A clear description of the problem that this pull request is solving. -->

When creating a PR stack, it's convenient in github to be able to navigate between each of the PRs quickly for review.

## Solution

<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Adding a new github action that modifies the github PR description to display the stack. See [screenshot here](https://github.com/marketplace/actions/git-town-github-action) for what it will look like.

## Testing

<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->

- [ ] Added automated tests.
- [ ] Manually tested. If you check this box, provide instructions for others to test, too.

## Notes for reviewers

<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->

<!-- branch-stack -->

- `main`
  - \#13 :point\_left:
