### PR TITLE
refactor: simplify creating mocks 

### DIFF
--- a/deploy.test.ts
+++ b/deploy.test.ts
@@ -1,32 +1,18 @@
 import { assertEquals } from "jsr:@std/assert@1";
 import { afterEach, describe, it } from "jsr:@std/testing@1/bdd";
 import { restore, stub } from "jsr:@std/testing@1/mock";
-import {
-  GetLatestReleaseStep,
-  GetLatestReleaseStepImpl,
-} from "./lib/steps/get-latest-release.ts";
+import { GetLatestReleaseStep } from "./lib/steps/get-latest-release.ts";
 import { run } from "./deploy.ts";
-import {
-  GitHubApiImpl,
-  GitHubCommit,
-  GitHubRelease,
-} from "./lib/github-api.ts";
+import { GitHubCommit, GitHubRelease } from "./lib/github-api.ts";
 import { GitHubCommitFake, GitHubReleaseFake } from "./lib/github-api.test.ts";
 import {
   GetCommitsSinceLatestReleaseStep,
-  GetCommitsSinceLatestReleaseStepImpl,
 } from "./lib/steps/get-commits-since-latest-release.ts";
 import {
   DetermineNextReleaseStep,
-  DetermineNextReleaseStepImpl,
 } from "./lib/steps/determine-next-release.ts";
-import {
-  CreateNewReleaseStep,
-  CreateNewReleaseStepImpl,
-} from "./lib/steps/create-new-release.ts";
-import { DeployStep, DeployStepImpl } from "./lib/steps/deploy.ts";
-import { exec } from "./lib/exec.ts";
-import { git } from "./lib/git.ts";
+import { CreateNewReleaseStep } from "./lib/steps/create-new-release.ts";
+import { DeployStep } from "./lib/steps/deploy.ts";
 
 describe("run the tool", () => {
   afterEach(() => {
@@ -108,7 +94,7 @@ const setupTestEnvironmentAndRun = async ({
   Deno.env.set("GITHUB_REPOSITORY", "levibostian/new-deployment-tool");
   Deno.env.set("DRY_RUN", "false");
 
-  const getLatestReleaseStep = new GetLatestReleaseStepImpl(GitHubApiImpl);
+  const getLatestReleaseStep = {} as GetLatestReleaseStep;
   const getLatestReleaseStepMock = stub(
     getLatestReleaseStep,
     "getLatestReleaseForBranch",
@@ -118,7 +104,7 @@ const setupTestEnvironmentAndRun = async ({
   );
 
   const getCommitsSinceLatestReleaseStep =
-    new GetCommitsSinceLatestReleaseStepImpl(GitHubApiImpl);
+    {} as GetCommitsSinceLatestReleaseStep;
   const getCommitsSinceLatestReleaseStepMock = stub(
     getCommitsSinceLatestReleaseStep,
     "getAllCommitsSinceGivenCommit",
@@ -127,7 +113,7 @@ const setupTestEnvironmentAndRun = async ({
     },
   );
 
-  const determineNextReleaseStep = new DetermineNextReleaseStepImpl();
+  const determineNextReleaseStep = {} as DetermineNextReleaseStep;
   const determineNextReleaseStepMock = stub(
     determineNextReleaseStep,
     "getNextReleaseVersion",
@@ -136,12 +122,12 @@ const setupTestEnvironmentAndRun = async ({
     },
   );
 
-  const deployStep = new DeployStepImpl(exec, git);
+  const deployStep = {} as DeployStep;
   const deployStepMock = stub(deployStep, "runDeploymentCommands", async () => {
     return gitCommitCreatedDuringDeploy || null;
   });
 
-  const createNewReleaseStep = new CreateNewReleaseStepImpl(GitHubApiImpl);
+  const createNewReleaseStep = {} as CreateNewReleaseStep;
   const createNewReleaseStepMock = stub(
     createNewReleaseStep,
     "createNewRelease",


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

This is my first project creating mocks in Deno. Before this PR, creating mocks felt weird because we were creating real instances of objects before mocking: 

```ts
stub(new StepImpl(git), ...)
```

We should not need to create production instances of objects to mock them. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

This change simply refactors the code to: 

```ts
stub({} as Step, ...)
```

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

As long as existing tests pass, we can assume a successful refactor. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->