### PR TITLE
fix: alpha cannot deploy because it's pointing to main branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: ${{ github.token }}
   version:
     description: 'Version of the CLI to use.'
-    default: 'main' # using branch name for now for easier deployments 
+    default: 'alpha' # using branch name for now for easier deployments 
   deploy_commands:
     description: 'List of commands to run to deploy your project.'
     required: true


### PR DESCRIPTION
When trying to make a alpha deployment, it failed because it’s trying to run the wrong version of tool (main branch over alpha branch). 