### PR TITLE
fix: get next release version config not being read

### DIFF
--- a/.github/workflows/deploy-action.yml
+++ b/.github/workflows/deploy-action.yml
@@ -14,11 +14,12 @@ jobs:
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.ref_name }} 
           analyze_commits_config: |
             {
-              'branches': [
-                {branch_name: 'main', prerelease: false},
-                {branch_name: 'beta', prerelease: true},
-                {branch_name: 'alpha', prerelease: true}
+              "branches": [
+                { "branch_name": "main", "prerelease": false },
+                { "branch_name": "beta", "prerelease": true },
+                { "branch_name": "alpha", "prerelease": true }
               ]
             } 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,7 @@ jobs:
         # Test that the config is read by the tool and pre-release versions are working. 
         analyze_commits_config: |
           {
-            'branches': [
-              {branch_name: '${{ github.ref_name }}', prerelease: true},
-              {branch_name: 'alpha', prerelease: true}
+            "branches": [
+              { "branch_name": "${{ github.ref_name }}", "prerelease": true, "version_suffix": "test" }
             ]
-          } 
+          }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,11 @@ jobs:
         version: ${{ github.sha }}
         dry_run_mode: 'true'
         github_token: ${{ secrets.github_token }}
+        # Test that the config is read by the tool and pre-release versions are working. 
+        analyze_commits_config: |
+          {
+            'branches': [
+              {branch_name: '${{ github.ref_name }}', prerelease: true},
+              {branch_name: 'alpha', prerelease: true}
+            ]
+          } 

--- a/README.md
+++ b/README.md
@@ -198,11 +198,12 @@ While developing new features of a project, it can be convenient to create prere
     # 'prerelease' to true. 
     analyze_commits_config: |
       {
-        'branches': [
-          {branch_name: 'beta', prerelease: true, version_suffix: 'beta'},
-          {branch_name: 'alpha', prerelease: true, version_suffix: 'alpha'}
+        "branches": [
+          { "branch_name": "main", "prerelease": false },
+          { "branch_name": "beta", "prerelease": true },
+          { "branch_name": "alpha", "prerelease": true }
         ]
-      }
+      } 
 ```
 
 The example above will create pre-production releases when code is pushed to both the `alpha` and `beta` branches. 

--- a/action.yml
+++ b/action.yml
@@ -37,3 +37,4 @@ runs:
         DRY_RUN: ${{ inputs.dry_run_mode }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_DEPLOY_COMMANDS: ${{ inputs.deploy_commands }}
+        INPUT_ANALYZE_COMMITS_CONFIG: ${{ inputs.analyze_commits_config }}

--- a/deploy.ts
+++ b/deploy.ts
@@ -27,6 +27,7 @@ export const run = async ({
   // Parse the configuration set by the user first so we can fail early if the configuration is invalid. Fast feedback for the user. 
   // Have the function throw if the JSON parsing fails. it will then exit the function. 
   const determineNextReleaseStepConfig = githubActions.getDetermineNextReleaseStepConfig();
+  log.debug(`determine next release step config: ${JSON.stringify(determineNextReleaseStepConfig)}`);
 
   log.notice(`👋 Hello! I am a tool called new-deployment-tool. I help you deploy your projects.`);
   log.message(

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -44,6 +44,5 @@ Deno.test("getDetermineNextReleaseStepConfig throws error when env variable is s
       githubActions.getDetermineNextReleaseStepConfig();
     },
     Error,
-    "When trying to parse the GitHub Actions input value for analyze_commits_config, I encountered an error"
   );
 });

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -1,4 +1,5 @@
 import { DetermineNextReleaseStepConfig } from "./steps/determine-next-release.ts";
+import * as log from './log.ts';
 
 export interface GitHubActions {
   getDetermineNextReleaseStepConfig(): DetermineNextReleaseStepConfig | undefined;
@@ -17,7 +18,10 @@ export class GitHubActionsImpl implements GitHubActions {
       // Because every property in the config is optional, if JSON.parse results in an object that is not a DetermineNextReleaseStepConfig, it's ok.
       return JSON.parse(determineNextReleaseStepConfig);
     } catch (error) {
-      throw new Error(`When trying to parse the GitHub Actions input value for ${githubActionInputKey}, I encountered an error: ${error}`);
+      log.error(`When trying to parse the GitHub Actions input value for ${githubActionInputKey}, I encountered an error: ${error}`);
+      log.error(`The value I tried to parse was: ${determineNextReleaseStepConfig}`);
+
+      throw new Error();
     }
   }
 }


### PR DESCRIPTION
Still having issues trying to get an alpha release made. This time, I realized that the JSON I passed to the action was not valid. The automated tests all work (and were valid JSON) but the JSON sent to the action was not. 

<!-- branch-stack -->

- `alpha`
  - \#29 :point\_left:
