### PR TITLE
refactor: detect if tool is running in a pull_request or push

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
 
   test-it-runs:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' # Only run on PRs, otherwise we will trigger a deployment by accident. 
     permissions:    
       contents: read # only offer read permissions for dry-run to prevent accidental deployments
     steps:
@@ -50,7 +51,6 @@ jobs:
       uses: ./      
       with: 
         version: ${{ github.sha }}
-        dry_run_mode: 'true'
         github_token: ${{ secrets.github_token }}
         # Test that the config is read by the tool and pre-release versions are working. 
         analyze_commits_config: |

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ If your team is not used to using a special format for git commit messages, you 
 This tool provides you with outputs to help you understand what happened during the deployment process.
 
 * `new_release_version` - If a new release was created, this is the version of that release.
+* `test_mode_on` - If test mode was on when the tool ran. Value is string values "true" or "false".
 
 # Configuration 
 
@@ -251,7 +252,7 @@ but it can help in certain situations.
 
 Replace the github URL with `deploy.ts` to tell Deno to run the local file not
 the remote file. Add 2 extra environment variables...
-`DRY_RUN=true INPUT_GITHUB_TOKEN="XXX" deno...`
+`GITHUB_EVENT_NAME=pull_request INPUT_GITHUB_TOKEN="XXX" deno...`
 
 # Tests
 

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,6 @@ inputs:
     description: 'List of commands to run to deploy your project.'
     required: true
     default: ''
-  dry_run_mode:
-    description: 'Run the deployment tool in dry-run mode. Note: this is currently for internal use only and API may change.'
-    default: 'false'
   analyze_commits_config:
     description: 'Configure the behavior when analyzing commits.'
     default: ''
@@ -23,6 +20,9 @@ outputs:
   new_release_version:
     description: 'If a new release was created, this is the version of that release.'
     value: ${{ steps.deployment.outputs.new_release_version }}
+  test_mode_on:
+    description: 'If test mode was on when the tool ran. Value is string values "true" or "false".'
+    value: ${{ steps.deployment.outputs.test_mode_on }}
 
 runs:
   using: "composite"
@@ -36,11 +36,10 @@ runs:
       # Deno's runtime permissions are a great feature. It would be nice to take advantage of it, however, it may not be possible with future features like running plugins. 
       #
       # The directories we are giving permission to read and write to are the temp directories for all of the OSes that GitHub Actions supports. /tmp for linux and /var/folders for macOS.
-      run: deno run --allow-env=GITHUB_REF,DRY_RUN,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN,INPUT_DEPLOY_COMMANDS,INPUT_ANALYZE_COMMITS_CONFIG --allow-net="api.github.com" --allow-run --allow-read="/tmp,/var/folders" --allow-write="/tmp,/var/folders" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/index.ts
+      run: deno run --allow-env=GITHUB_REF,GITHUB_EVENT_NAME,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN,INPUT_DEPLOY_COMMANDS,INPUT_ANALYZE_COMMITS_CONFIG --allow-net="api.github.com" --allow-run --allow-read="/tmp,/var/folders" --allow-write="/tmp,/var/folders" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/index.ts
       id: deployment
       shell: bash 
       env:
-        DRY_RUN: ${{ inputs.dry_run_mode }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_DEPLOY_COMMANDS: ${{ inputs.deploy_commands }}
         INPUT_ANALYZE_COMMITS_CONFIG: ${{ inputs.analyze_commits_config }}

--- a/lib/exec.test.ts
+++ b/lib/exec.test.ts
@@ -8,7 +8,7 @@ const givenPluginInput: DeployEnvironment = {
   gitRepoName: "repo",
   gitCommitsSinceLastRelease: [],
   nextVersionName: "1.0.0",
-  isDryRun: false,
+  testMode: true,
   lastRelease: null,
 };
 

--- a/lib/steps/deploy.test.ts
+++ b/lib/steps/deploy.test.ts
@@ -18,7 +18,7 @@ const defaultEnvironment: DeployEnvironment = {
   gitRepoName: "repo",
   gitCommitsSinceLastRelease: [],
   nextVersionName: "1.0.0",
-  isDryRun: false,
+  testMode: true,
   lastRelease: null, 
 };
 
@@ -102,15 +102,17 @@ describe("run the user given deploy commands", () => {
   it("should run normally and succeed, given no deploy commands", async () => {
     Deno.env.delete("INPUT_DEPLOY_COMMANDS");
 
-    stub(git, "commit", async (args) => {
+    // Fail if any git commands are run
+    stub(exec, "run", async (args) => {
       return {
-        sha: "123",
-        message: "success",
-        date: new Date(),
+        exitCode: 1,
+        stdout: "error",
+        output: undefined,
       };
     });
-    stub(git, "push", async (args) => {
-      return;
+
+    stub(git, "areAnyFilesStaged", async (args) => {
+      return false
     });
 
     await new DeployStepImpl(exec, git).runDeploymentCommands({

--- a/lib/steps/deploy.ts
+++ b/lib/steps/deploy.ts
@@ -82,7 +82,7 @@ export class DeployStepImpl implements DeployStep {
       // First part of using branches that we control is delete the existing local branch if it exists. This ensures that we have a clean slate for this deployment and prevents some git errors. 
       // If the previous deployment failed, there is a chance that the branch already exists. We want a clean slate for the deployment so we want this branch gone. 
       if (await this.git.doesLocalBranchExist({ exec: this.exec, branch: deploymentBranchName })) {
-        await this.git.deleteBranch({ exec: this.exec, branch: deploymentBranchName, dryRun: environment.isDryRun });
+        await this.git.deleteBranch({ exec: this.exec, branch: deploymentBranchName, dryRun: environment.testMode });
       } 
 
       // Create and checkout the branch for the deployment. Sometimes, git will not allow you to checkout a different branch if you have changes that need committing. 
@@ -92,13 +92,13 @@ export class DeployStepImpl implements DeployStep {
       gitCommitCreated = await this.git.commit({
         exec: this.exec,
         message: `Deploy version ${environment.nextVersionName}`,
-        dryRun: environment.isDryRun,
+        dryRun: environment.testMode,
       });
       await this.git.push({
         exec: this.exec,
         branch: deploymentBranchName,
         forcePush: true, // if a previous deployment failed, this branch could exist on remote. Force push will cleanup remote branch. It's safe since we control this branch. 
-        dryRun: environment.isDryRun,
+        dryRun: environment.testMode,
       });
 
       log.message(`Deployment changes have been pushed to your GitHub repo. You can view the changes here: https://github.com/${environment.gitRepoOwner}/${environment.gitRepoName}/tree/${deploymentBranchName}`);

--- a/lib/steps/determine-next-release.test.ts
+++ b/lib/steps/determine-next-release.test.ts
@@ -13,7 +13,7 @@ const defaultEnvironment = {
   gitCommitsSinceLastRelease: [],
   gitRepoOwner: "owner",
   gitRepoName: "repo",
-  isDryRun: false,
+  testMode: false,
 };
 
 Deno.test("given this is first release, not prerelease, expect default version", async () => {

--- a/lib/types/environment.ts
+++ b/lib/types/environment.ts
@@ -10,7 +10,7 @@ export interface GetLatestReleaseEnvironment {
   gitCurrentBranch: string
   gitRepoOwner: string,
   gitRepoName: string,
-  isDryRun: boolean,
+  testMode: boolean,
 }
 
 export interface GetNextReleaseVersionEnvironment extends GetLatestReleaseEnvironment {


### PR DESCRIPTION
This tool encourages running it for both push and pull request events on github actions. That way you can validate that it's working as intended.

We detect how the tool executed so that we can automatically enable "test\_mode" (previously called dry run in the codebase).

***

**Stack**:

- \#41
- \#40
- \#39
- \#38
- \#37
- \#36
- \#35 ⬅

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

- `alpha` <!-- branch-stack -->
  - \#35 :point\_left:
    - \#36
      - \#37
        - \#38
          - \#39
            - \#40
              - \#41
