### PR TITLE
fix: github actions set-output is deprecated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
       # Deno's runtime permissions are a great feature. It would be nice to take advantage of it, however, it may not be possible with future features like running plugins. 
       #
       # The directories we are giving permission to read and write to are the temp directories for all of the OSes that GitHub Actions supports. /tmp for linux and /var/folders for macOS.
-      run: deno run --allow-env=GITHUB_EVENT_PATH,GITHUB_REF,GITHUB_EVENT_NAME,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN,INPUT_DEPLOY_COMMANDS,INPUT_ANALYZE_COMMITS_CONFIG --allow-net="api.github.com" --allow-run --allow-read="/tmp,/var/folders,/home/runner/work/_temp/_github_workflow" --allow-write="/tmp,/var/folders" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/index.ts
+      run: deno run --allow-env=GITHUB_OUTPUT,GITHUB_EVENT_PATH,GITHUB_REF,GITHUB_EVENT_NAME,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN,INPUT_DEPLOY_COMMANDS,INPUT_ANALYZE_COMMITS_CONFIG --allow-net="api.github.com" --allow-run --allow-read="/tmp,/var/folders,/home/runner/work/_temp" --allow-write="/tmp,/var/folders,/home/runner/work/_temp" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/index.ts
       id: deployment
       shell: bash 
       env:


### PR DESCRIPTION
When running the tool, I get warning:
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>

But I'm using the latest 1.11.0 version of actions/core npm module so this shouldn't happen? I found the PR that implemented a fix for the deprecation, <https://github.com/actions/toolkit/pull/1178>, and in it, I see that it checks if it has access to the GITHUB\_OUTPUT environment variable. If it doesn't, it will fallback to previous behavior.

***

**Stack**:

- \#41
- \#40 ⬅
- \#39
- \#38
- \#37
- \#36
- \#35

⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

- `alpha` <!-- branch-stack -->
  - \#35
    - \#36
      - \#37
        - \#38
          - \#39
            - \#40 :point\_left:
              - \#41
