### PR TITLE
refactor: move git commands out of action.yml and into deno code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,21 +37,6 @@ runs:
       uses: denoland/setup-deno@v1
       with:
         deno-version: v1.x
-    
-    - name: Fetch all branches so we can reference base branch to merge into 
-      run: git fetch
-      shell: bash 
-
-    - name: Pull all branches so it's available locally and we can view the commit history of all branches 
-      run: |
-        git config pull.rebase false  # or true or ff only, depending on your preference
-        
-        for branch in $(git branch -r | grep -v '\->'); do
-          local_branch="${branch#origin/}"
-          git branch --track "$local_branch" "$branch" || true
-          git pull origin "$local_branch" || true
-        done
-      shell: bash
 
     - name: Find pull request comment previously created, if there is one. 
       if: ${{ github.event_name == 'pull_request' }}

--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ const githubApi = GitHubApiImpl;
 const githubActions = new GitHubActionsImpl();
 
 await run({
-  prepareEnvironmentForTestMode: new PrepareTestModeEnvStepImpl(githubApi, githubActions, new SimulateMergeImpl(git, exec)),
+  prepareEnvironmentForTestMode: new PrepareTestModeEnvStepImpl(githubApi, githubActions, new SimulateMergeImpl(git, exec), git, exec),
   getLatestReleaseStep: new GetLatestReleaseStepImpl(githubApi),
   getCommitsSinceLatestReleaseStep: new GetCommitsSinceLatestReleaseStepImpl(
     githubApi,

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -126,6 +126,8 @@ const run = async (
   );
 
   const code = (await child.status).code;
+  if (capturedStdout) log.debug(capturedStdout);
+  if (capturedStderr) log.debug(capturedStderr);
 
   let commandOutput: DeployCommandOutput | undefined;
 

--- a/lib/steps/prepare-testmode-env.test.ts
+++ b/lib/steps/prepare-testmode-env.test.ts
@@ -6,6 +6,8 @@ import { SimulateMerge } from "../simulate-merge.ts";
 import { PrepareTestModeEnvStepImpl } from "./prepare-testmode-env.ts";
 import { mock, when } from "../mock/mock.ts";
 import { GitHubCommitFake } from "../github-api.test.ts";
+import { Git } from "../git.ts";
+import { Exec } from "../exec.ts";
 
 describe("prepareEnvironmentForTestMode", () => {
   let step: PrepareTestModeEnvStepImpl;
@@ -13,16 +15,22 @@ describe("prepareEnvironmentForTestMode", () => {
   let githubActions: GitHubActions;
   let gitHubApi: GitHubApi
   let simulateMerge: SimulateMerge;
+  let git: Git;
+  let exec: Exec;
   
   beforeEach(() => {
     githubActions = mock();
     gitHubApi = mock();
     simulateMerge = mock();
+    git = mock();
+    exec = mock();
 
     step = new PrepareTestModeEnvStepImpl(
       gitHubApi,
       githubActions,
       simulateMerge,
+      git,
+      exec,
     );
   })
 
@@ -41,6 +49,7 @@ describe("prepareEnvironmentForTestMode", () => {
   it("should perform simulated merge on all pull requests in stack, given multiple pull requests in stack, expect to get list of commits made", async () => {
     const givenMergeType: 'merge' | 'squash' | 'rebase' = 'merge';
 
+    when(git, "createLocalBranchFromRemote", async () => {});
     when(githubActions, "getSimulatedMergeType", () => givenMergeType);
     when(githubActions, "isRunningInPullRequest", async () => ({baseBranch: "feature-branch-2", targetBranch: "feature-branch-1", prTitle: "title", prDescription: "description"}));
 


### PR DESCRIPTION
## Problem
<!-- A clear description of the problem that this pull request is solving. -->

Moved some git commands out of action.yml and into the tool's source code. 

- decouples the tool from the CI environment some more
- makes the code easier to understand as it's encapsulated
- better performance as we no longer need to pull *all* branches in a repo, but just the ones we need. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Implement the git commands into the source code. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

Ran the tool on this PR 😄 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->