### PR TITLE
refactor: update all dependencies and transition to lock file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ jobs:
       with:
         deno-version: v2.x
 
+    - name: Install dependencies
+      run: deno install --frozen
+
     - name: Run Deno tests
       run: deno test --allow-env --allow-run --allow-read --allow-write --junit-path reports/junit.xml --coverage=reports/coverage/    
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ runs:
       with:
         deno-version: v2.x
 
+    - name: Install dependencies
+      run: deno install --frozen
+      shell: bash
+
     - name: Find pull request comment previously created, if there is one. 
       if: ${{ github.event_name == 'pull_request' }}
       uses: peter-evans/find-comment@v3

--- a/action.yml
+++ b/action.yml
@@ -38,8 +38,8 @@ runs:
       with:
         deno-version: v2.x
 
-    - name: Install dependencies
-      run: deno install --frozen
+    - name: Compile the CLI
+      run: deno task compile
       shell: bash
 
     - name: Find pull request comment previously created, if there is one. 
@@ -68,7 +68,7 @@ runs:
       # Deno's runtime permissions are a great feature. It would be nice to take advantage of it, however, it may not be possible with future features like running plugins. 
       #
       # The directories we are giving permission to read and write to are the temp directories for all of the OSes that GitHub Actions supports. /tmp for linux and /var/folders for macOS.
-      run: deno run --allow-env=GITHUB_OUTPUT,GITHUB_EVENT_PATH,GITHUB_REF,GITHUB_HEAD_REF,GITHUB_EVENT_NAME,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN,INPUT_DEPLOY_COMMANDS,INPUT_ANALYZE_COMMITS_CONFIG --allow-net="api.github.com" --allow-run --allow-read="/tmp,/var/folders,/home/runner/work/_temp" --allow-write="/tmp,/var/folders,/home/runner/work/_temp" https://raw.githubusercontent.com/levibostian/new-deployment-tool/${{ inputs.version }}/index.ts
+      run: ./deployer
       id: deployment
       shell: bash 
       env:

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,10 @@
+{
+  "imports": {
+    "@actions/core": "npm:@actions/core@^1.11.1",
+    "@std/semver": "jsr:@std/semver@^1.0.4",
+    "@std/testing": "jsr:@std/testing@^1.0.10",
+    "@std/assert": "jsr:@std/assert@^1.0.12",
+    "ansi-styles": "npm:ansi-styles@6.2.1",
+    "shell-quote": "npm:shell-quote@^1.8.2"
+  }
+}

--- a/deno.json
+++ b/deno.json
@@ -6,5 +6,8 @@
     "@std/assert": "jsr:@std/assert@^1.0.12",
     "ansi-styles": "npm:ansi-styles@6.2.1",
     "shell-quote": "npm:shell-quote@^1.8.2"
+  },
+  "tasks": {
+    "compile": "deno compile --output deployer --frozen --allow-env=GITHUB_OUTPUT,GITHUB_EVENT_PATH,GITHUB_REF,GITHUB_HEAD_REF,GITHUB_EVENT_NAME,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN,INPUT_DEPLOY_COMMANDS,INPUT_ANALYZE_COMMITS_CONFIG --allow-net=\"api.github.com\" --allow-run --allow-read=\"/tmp,/var/folders,/home/runner/work/_temp\" --allow-write=\"/tmp,/var/folders,/home/runner/work/_temp\" index.ts"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,129 @@
+{
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.12",
+    "jsr:@std/assert@^1.0.12": "1.0.12",
+    "jsr:@std/async@^1.0.12": "1.0.12",
+    "jsr:@std/data-structures@^1.0.6": "1.0.6",
+    "jsr:@std/fs@^1.0.15": "1.0.15",
+    "jsr:@std/internal@^1.0.6": "1.0.6",
+    "jsr:@std/path@^1.0.8": "1.0.8",
+    "jsr:@std/semver@*": "1.0.4",
+    "jsr:@std/semver@^1.0.4": "1.0.4",
+    "jsr:@std/testing@1": "1.0.10",
+    "jsr:@std/testing@^1.0.10": "1.0.10",
+    "npm:@actions/core@*": "1.11.1",
+    "npm:@actions/core@^1.11.1": "1.11.1",
+    "npm:ansi-styles@6.2.1": "6.2.1",
+    "npm:shell-quote@1.8.1": "1.8.1",
+    "npm:shell-quote@^1.8.2": "1.8.2"
+  },
+  "jsr": {
+    "@std/assert@1.0.12": {
+      "integrity": "08009f0926dda9cbd8bef3a35d3b6a4b964b0ab5c3e140a4e0351fbf34af5b9a",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/async@1.0.12": {
+      "integrity": "d1bfcec459e8012846fe4e38dfc4241ab23240ecda3d8d6dfcf6d81a632e803d"
+    },
+    "@std/data-structures@1.0.6": {
+      "integrity": "76a7fd8080c66604c0496220a791860492ab21a04a63a969c0b9a0609bbbb760"
+    },
+    "@std/fs@1.0.15": {
+      "integrity": "c083fb479889d6440d768e498195c3fc499d426fbf9a6592f98f53884d1d3f41",
+      "dependencies": [
+        "jsr:@std/path"
+      ]
+    },
+    "@std/internal@1.0.6": {
+      "integrity": "9533b128f230f73bd209408bb07a4b12f8d4255ab2a4d22a1fd6d87304aca9a4"
+    },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    },
+    "@std/semver@1.0.4": {
+      "integrity": "a62af791917d8fd6c48d6ebbb872f83fad3fc6671ffadbbd39ea229c2d34d175"
+    },
+    "@std/testing@1.0.10": {
+      "integrity": "8997bd0b0df020b81bf5eae103c66622918adeff7e45e96291c92a29dbf82cc1",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.12",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs",
+        "jsr:@std/internal",
+        "jsr:@std/path"
+      ]
+    }
+  },
+  "npm": {
+    "@actions/core@1.11.1": {
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "dependencies": [
+        "@actions/exec",
+        "@actions/http-client"
+      ]
+    },
+    "@actions/exec@1.1.1": {
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dependencies": [
+        "@actions/io"
+      ]
+    },
+    "@actions/http-client@2.2.3": {
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "dependencies": [
+        "tunnel",
+        "undici"
+      ]
+    },
+    "@actions/io@1.1.3": {
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+    },
+    "@fastify/busboy@2.1.1": {
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+    },
+    "ansi-styles@6.2.1": {
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
+    },
+    "shell-quote@1.8.1": {
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA=="
+    },
+    "shell-quote@1.8.2": {
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA=="
+    },
+    "tunnel@0.0.6": {
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
+    "undici@5.28.4": {
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dependencies": [
+        "@fastify/busboy"
+      ]
+    }
+  },
+  "remote": {
+    "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
+    "https://deno.land/std@0.224.0/assert/assert_equals.ts": "3bbca947d85b9d374a108687b1a8ba3785a7850436b5a8930d81f34a32cb8c74",
+    "https://deno.land/std@0.224.0/assert/assert_is_error.ts": "f856b3bc978a7aa6a601f3fec6603491ab6255118afa6baa84b04426dd3cc491",
+    "https://deno.land/std@0.224.0/assert/assert_throws.ts": "c6508b2879d465898dab2798009299867e67c570d7d34c90a2d235e4553906eb",
+    "https://deno.land/std@0.224.0/assert/assertion_error.ts": "ba8752bd27ebc51f723702fac2f54d3e94447598f54264a6653d6413738a8917",
+    "https://deno.land/std@0.224.0/assert/equal.ts": "bddf07bb5fc718e10bb72d5dc2c36c1ce5a8bdd3b647069b6319e07af181ac47",
+    "https://deno.land/std@0.224.0/fmt/colors.ts": "508563c0659dd7198ba4bbf87e97f654af3c34eb56ba790260f252ad8012e1c5",
+    "https://deno.land/std@0.224.0/internal/diff.ts": "6234a4b493ebe65dc67a18a0eb97ef683626a1166a1906232ce186ae9f65f4e6",
+    "https://deno.land/std@0.224.0/internal/format.ts": "0a98ee226fd3d43450245b1844b47003419d34d210fa989900861c79820d21c2",
+    "https://deno.land/std@0.224.0/internal/mod.ts": "534125398c8e7426183e12dc255bb635d94e06d0f93c60a297723abe69d3b22e"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@^1.0.12",
+      "jsr:@std/semver@^1.0.4",
+      "jsr:@std/testing@^1.0.10",
+      "npm:@actions/core@^1.11.1",
+      "npm:ansi-styles@6.2.1",
+      "npm:shell-quote@^1.8.2"
+    ]
+  }
+}

--- a/deploy.test.ts
+++ b/deploy.test.ts
@@ -1,7 +1,7 @@
-import { assertEquals } from "jsr:@std/assert@1";
-import { afterEach, describe, it } from "jsr:@std/testing@1/bdd";
-import { restore, stub } from "jsr:@std/testing@1/mock";
-import { assertSnapshot } from "jsr:@std/testing@1/snapshot";
+import { assertEquals } from "@std/assert";
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { restore, stub } from "@std/testing/mock";
+import { assertSnapshot } from "@std/testing/snapshot";
 import { GetLatestReleaseStep } from "./lib/steps/get-latest-release.ts";
 import { run } from "./deploy.ts";
 import { GitHubCommit, GitHubRelease } from "./lib/github-api.ts";

--- a/lib/conventional-commits.test.ts
+++ b/lib/conventional-commits.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/assert_equals.ts";
+import { assertEquals } from "@std/assert"
 import { versionBumpForCommitBasedOnConventionalCommit } from "./conventional-commits.ts";
 import { GitHubCommit } from "./github-api.ts";
 

--- a/lib/exec.test.ts
+++ b/lib/exec.test.ts
@@ -1,5 +1,5 @@
 import { exec } from "./exec.ts";
-import { assertEquals } from "jsr:@std/assert@1";
+import { assertEquals } from "@std/assert";
 import { DeployEnvironment } from "./types/environment.ts";
 
 const givenPluginInput: DeployEnvironment = {

--- a/lib/exec.ts
+++ b/lib/exec.ts
@@ -3,7 +3,7 @@ import {
   isDeployCommandOutput,
 } from "./steps/types/deploy.ts";
 import * as log from "./log.ts";
-import * as shellQuote from "npm:shell-quote@1.8.1";
+import * as shellQuote from "shell-quote";
 import { DeployEnvironment } from "./types/environment.ts";
 
 export interface RunResult {

--- a/lib/git.test.ts
+++ b/lib/git.test.ts
@@ -2,13 +2,13 @@ import {
   assertEquals,
   assertFalse,
   assertRejects,
-} from "jsr:@std/assert@1";
-import { afterEach, describe, it } from "jsr:@std/testing@1/bdd";
+} from "@std/assert";
+import { afterEach, describe, it } from "@std/testing/bdd";
 import {
   assertSpyCall,
   restore,
   stub,
-} from "jsr:@std/testing@1/mock";
+} from "@std/testing/mock";
 import { exec, RunResult } from "./exec.ts";
 import { git } from "./git.ts";
 

--- a/lib/github-actions.test.ts
+++ b/lib/github-actions.test.ts
@@ -1,5 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/assert_equals.ts";
-import { assertThrows } from "https://deno.land/std@0.224.0/assert/assert_throws.ts";
+import { assertEquals, assertThrows } from "@std/assert"
 import { GitHubActionsImpl } from "./github-actions.ts";
 import { DetermineNextReleaseStepConfig } from "./steps/determine-next-release.ts";
 

--- a/lib/github-actions.ts
+++ b/lib/github-actions.ts
@@ -1,6 +1,6 @@
 import { DetermineNextReleaseStepConfig } from "./steps/determine-next-release.ts";
 import * as log from './log.ts';
-import * as githubActions from 'npm:@actions/core';
+import * as githubActions from '@actions/core';
 
 export interface GitHubActions {
   getNameOfCurrentBranch(): string;

--- a/lib/github-api.test.ts
+++ b/lib/github-api.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "jsr:@std/assert@1";
-import { afterEach, beforeEach, describe, it } from "jsr:@std/testing@1/bdd";
+import { assertEquals } from "@std/assert";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { GitHubApiImpl, GitHubCommit, GitHubRelease } from "./github-api.ts";
 
 export const GitHubReleaseFake: GitHubRelease = {

--- a/lib/log.test.ts
+++ b/lib/log.test.ts
@@ -1,4 +1,4 @@
-import { stub } from "jsr:@std/testing@1/mock";
+import { stub } from "@std/testing/mock";
 import { Logger } from "./log.ts";
 
 export interface LogMock extends Logger {

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -1,4 +1,4 @@
-import colors from "npm:ansi-styles@6.2.1";
+import colors from "ansi-styles";
 
 // log.ts
 // This module provides a simple API for logging messages at different levels to GitHub Actions.

--- a/lib/mock/mock.ts
+++ b/lib/mock/mock.ts
@@ -1,4 +1,4 @@
-import { stub, spy, GetParametersFromProp, GetReturnFromProp, Stub } from "jsr:@std/testing@1/mock";
+import { stub, spy, GetParametersFromProp, GetReturnFromProp, Stub } from "@std/testing/mock";
 
 /**
  * Example: 

--- a/lib/simulate-merge.test.ts
+++ b/lib/simulate-merge.test.ts
@@ -2,19 +2,19 @@ import {
   assertEquals,
   assertFalse,
   assertRejects,
-} from "jsr:@std/assert@1";
-import { afterEach, before, beforeEach, describe, it } from "jsr:@std/testing@1/bdd";
+} from "@std/assert";
+import { afterEach, before, beforeEach, describe, it } from "@std/testing/bdd";
 import {
   assertSpyCall,
   restore,
   Stub,
   stub,
-} from "jsr:@std/testing@1/mock";
+} from "@std/testing/mock";
 import { exec, RunResult } from "./exec.ts";
 import { SimulateMerge, SimulateMergeImpl } from "./simulate-merge.ts"
 import { git } from "./git.ts";
 import { Exec } from "./exec.ts";
-import { assertSnapshot } from "jsr:@std/testing@1/snapshot";
+import { assertSnapshot } from "@std/testing/snapshot";
 
 describe("snapshot test all of the merge options", () => {
   let simulateMerge: SimulateMerge;

--- a/lib/steps/deploy.test.ts
+++ b/lib/steps/deploy.test.ts
@@ -1,11 +1,11 @@
-import { assertEquals, assertNotEquals, assertRejects } from "jsr:@std/assert@1";
-import { afterEach, beforeEach, describe, it } from "jsr:@std/testing@1/bdd";
+import { assertEquals, assertNotEquals, assertRejects } from "@std/assert";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import {
   assertSpyCall,
   assertSpyCallArg,
   restore,
   stub,
-} from "jsr:@std/testing@1/mock";
+} from "@std/testing/mock";
 import { exec } from "../exec.ts";
 import { DeployStep, DeployStepImpl } from "./deploy.ts";
 import { git } from "../git.ts";

--- a/lib/steps/determine-next-release.test.ts
+++ b/lib/steps/determine-next-release.test.ts
@@ -1,11 +1,11 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/assert_equals.ts";
+import { assertEquals } from "@std/assert"
 import { GitHubCommit, GitHubRelease } from "../github-api.ts";
 import { DetermineNextReleaseStepImpl } from "./determine-next-release.ts";
 import { GitHubCommitFake, GitHubReleaseFake } from "../github-api.test.ts";
-import { before, beforeEach, describe, it } from "jsr:@std/testing@1/bdd";
+import { before, beforeEach, describe, it } from "@std/testing/bdd";
 import { Logger } from "../log.ts";
 import { getLogMock, LogMock } from "../log.test.ts";
-import { assertSnapshot } from "jsr:@std/testing@1/snapshot";
+import { assertSnapshot } from "@std/testing/snapshot";
 
 const defaultEnvironment = {
   gitCurrentBranch: "main",

--- a/lib/steps/determine-next-release.ts
+++ b/lib/steps/determine-next-release.ts
@@ -1,5 +1,5 @@
 import { GitHubCommit, GitHubRelease } from "../github-api.ts";
-import * as semver from "jsr:@std/semver";
+import * as semver from "@std/semver";
 import { versionBumpForCommitBasedOnConventionalCommit } from "../conventional-commits.ts";
 import { Logger, logger } from "../log.ts";
 import { GetNextReleaseVersionEnvironment } from "../types/environment.ts";

--- a/lib/steps/get-commits-since-latest-release.test.ts
+++ b/lib/steps/get-commits-since-latest-release.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "jsr:@std/assert@1";
-import { afterEach, describe, it } from "jsr:@std/testing@1/bdd";
-import { restore, stub } from "jsr:@std/testing@1/mock";
+import { assertEquals } from "@std/assert";
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { restore, stub } from "@std/testing/mock";
 import { GitHubApiImpl } from "../github-api.ts";
 import { GetCommitsSinceLatestReleaseStepImpl } from "./get-commits-since-latest-release.ts";
 import { GitHubReleaseFake } from "../github-api.test.ts";

--- a/lib/steps/get-latest-release.test.ts
+++ b/lib/steps/get-latest-release.test.ts
@@ -1,6 +1,6 @@
-import { assertEquals } from "jsr:@std/assert@1";
-import { afterEach, describe, it } from "jsr:@std/testing@1/bdd";
-import { restore, stub } from "jsr:@std/testing@1/mock";
+import { assertEquals } from "@std/assert";
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { restore, stub } from "@std/testing/mock";
 import { GitHubApiImpl } from "../github-api.ts";
 import { GetLatestReleaseStepImpl } from "./get-latest-release.ts";
 

--- a/lib/steps/prepare-testmode-env.test.ts
+++ b/lib/steps/prepare-testmode-env.test.ts
@@ -1,5 +1,5 @@
-import { assert, assertEquals } from "jsr:@std/assert@1";
-import { beforeEach, describe, it } from "jsr:@std/testing@1/bdd";
+import { assert, assertEquals } from "@std/assert";
+import { beforeEach, describe, it } from "@std/testing/bdd";
 import { GitHubApi } from "../github-api.ts";
 import { GitHubActions } from "../github-actions.ts";
 import { SimulateMerge } from "../simulate-merge.ts";


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

Since we just updated to deno v2, I thought it would be nice to update the dependencies. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

I figured the easiest way to update the project's dependencies is to leverage deno's built-in mechanism for updating dependencies by using the lock file. 

An alternative approach is to go into each of the source code files and update the `http:...` import statements to a new version. So tedious. So, this PR moves over to the use of the `deno.lock` file so we can let deno update all our dependencies for us while still enforcing strict versioning for the whole project. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

The CI test suite. If it runs as expected, we consider it working. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->

1. This PR found a bug in the tool. [Fixed in another PR](https://github.com/levibostian/new-deployment-tool/pull/47).
2. This PR introduced the idea of compiling the tool into a binary and then running the binary instead of doing `deno run...`. [See commit description](https://github.com/levibostian/new-deployment-tool/pull/46/commits/5f6db04b0ec3bb2efd8d85e7c4cdc847dc3c6fc2) to learn more. This was done because the CI test suite failed after we [switched to the lockfile](https://github.com/levibostian/new-deployment-tool/pull/46/commits/ed454becf1fd7aef6db61bc60243b2cfca86619f) which showed limitations with `deno run`. 