### PR TITLE
fix: bug where tool says there are zero commits even after simulated merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       run: deno install --frozen
 
     - name: Run Deno tests
-      run: deno test --allow-env --allow-run --allow-read --allow-write --junit-path reports/junit.xml --coverage=reports/coverage/    
+      run: deno task test
 
     - name: Generate coverage report 
       run: deno coverage --lcov --output=reports/coverage.lcov reports/coverage/

--- a/deno.json
+++ b/deno.json
@@ -8,6 +8,7 @@
     "shell-quote": "npm:shell-quote@^1.8.2"
   },
   "tasks": {
-    "compile": "deno compile --output deployer --frozen --allow-env=GITHUB_OUTPUT,GITHUB_EVENT_PATH,GITHUB_REF,GITHUB_HEAD_REF,GITHUB_EVENT_NAME,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN,INPUT_DEPLOY_COMMANDS,INPUT_ANALYZE_COMMITS_CONFIG --allow-net=\"api.github.com\" --allow-run --allow-read=\"/tmp,/var/folders,/home/runner/work/_temp\" --allow-write=\"/tmp,/var/folders,/home/runner/work/_temp\" index.ts"
+    "compile": "deno compile --output deployer --frozen --allow-env=GITHUB_OUTPUT,GITHUB_EVENT_PATH,GITHUB_REF,GITHUB_HEAD_REF,GITHUB_EVENT_NAME,GITHUB_REPOSITORY,INPUT_GITHUB_TOKEN,INPUT_DEPLOY_COMMANDS,INPUT_ANALYZE_COMMITS_CONFIG --allow-net=\"api.github.com\" --allow-run --allow-read=\"/tmp,/var/folders,/home/runner/work/_temp\" --allow-write=\"/tmp,/var/folders,/home/runner/work/_temp\" index.ts",
+    "test": "deno test --allow-env --allow-run --allow-read --allow-write --junit-path reports/junit.xml --coverage=reports/coverage/"
   }
 }

--- a/deploy.ts
+++ b/deploy.ts
@@ -110,6 +110,11 @@ export const run = async ({
       branch: currentBranch,
       latestRelease: lastRelease,
     });
+
+  // if we are running in test mode and ran simulated merges, add those created commits to list of commits to have analyzed. 
+  // add commits to beginning of list as newest commits should be first in list, like `git log`
+  listOfCommits.unshift(...commitsCreatedDuringSimulatedMerges);
+
   if (listOfCommits.length === 0) {
     log.warning(
       `Looks like zero commits have been created since the latest release. This means there is no new code created and therefore, the deployment process stops here. Bye-bye 👋!`,
@@ -123,10 +128,6 @@ export const run = async ({
       JSON.stringify(listOfCommits[listOfCommits.length - 1])
     }`,
   );
-
-  // if we are running in test mode and ran simulated merges, add those created commits to list of commits to have analyzed. 
-  // add commits to beginning of list as newest commits should be first in list, like `git log`
-  listOfCommits.unshift(...commitsCreatedDuringSimulatedMerges);
 
   log.message(`I found ${listOfCommits.length} git commits created since ${lastRelease ? `the latest release of ${lastRelease.tag.name}` : `the git branch ${currentBranch} was created`}.`);
 


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

[Bug found in this PR](https://github.com/levibostian/new-deployment-tool/pull/46) (not introduced by that PR, just found when the CI ran). 

![CleanShot 2025-04-02 at 07 41 37](https://github.com/user-attachments/assets/8f65f05b-0c3e-44fb-b29e-2aefb19a6b23)

if the parent branch has zero commits (example: merging a PR into main branch and main branch currently has no new commits in it since last release) and you do a simulated merge, we expect that the tool analyzes those simulated merges. Actual behavior with the bug is it exits early.

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->