### PR TITLE
fix: tool creates and updates only 1 comment in PR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,7 @@ runs:
         
     - name: Create or update pull request comment with new deployment tool output
       uses: peter-evans/create-or-update-comment@v4
+      id: create-or-update-comment
       if: ${{ github.event_name == 'pull_request' && inputs.make_pull_request_comment == 'true' }}
       with:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
@@ -80,7 +81,7 @@ runs:
       uses: peter-evans/create-or-update-comment@v4
       if: ${{ inputs.make_pull_request_comment == 'true' && steps.deployment.outputs.test_mode_on == 'true' && steps.deployment.outcome != 'success' }}
       with:
-        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        comment-id: ${{ steps.create-or-update-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           <!-- new-deployment-tool-deploy-run-output -->
@@ -92,7 +93,7 @@ runs:
       uses: peter-evans/create-or-update-comment@v4
       if: ${{ inputs.make_pull_request_comment == 'true' && steps.deployment.outputs.test_mode_on == 'true' && steps.deployment.outcome == 'success' && steps.deployment.outputs.new_release_version != '' }}
       with:
-        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        comment-id: ${{ steps.create-or-update-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           <!-- new-deployment-tool-deploy-run-output -->
@@ -105,7 +106,7 @@ runs:
       uses: peter-evans/create-or-update-comment@v4
       if: ${{ inputs.make_pull_request_comment == 'true' && steps.deployment.outputs.test_mode_on == 'true' && steps.deployment.outcome == 'success' && steps.deployment.outputs.new_release_version == '' }}
       with:
-        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        comment-id: ${{ steps.create-or-update-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           <!-- new-deployment-tool-deploy-run-output -->


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

Found a bug in the code. 

Expected behavior: tool only ever has 1 comment existing in a PR. It updates the same one over and over.
Actual behavior: 2+ comments exist in a PR.

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Noticed we were using the wrong github step to find the comment id. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

Testing in this PR. Run tool multiple times in this 1 PR and expect to only ever have 1 comment at a given time. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->