### PR TITLE
feat: allow running multiple times to run multiple simulated types

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,19 +48,43 @@ runs:
         comment-author: 'github-actions[bot]'
         body-includes: '<!-- new-deployment-tool-deploy-run-output -->'
         token: ${{ inputs.github_token }}  
+
+    - name: Find pull request comment previously created for this particular run, if there is one.
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: peter-evans/find-comment@v3
+      id: find-comment-job
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: '<!-- run-${{ github.run_id }} -->'
+        token: ${{ inputs.github_token }}  
         
     - name: Create or update pull request comment with new deployment tool output
       uses: peter-evans/create-or-update-comment@v4
       id: create-or-update-comment
-      if: ${{ github.event_name == 'pull_request' && inputs.make_pull_request_comment == 'true' }}
+      # only replace comment if there isn't one already created for this run
+      if: ${{ github.event_name == 'pull_request' && inputs.make_pull_request_comment == 'true' && steps.find-comment-job.outputs.comment-id == '' }}
       with:
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           <!-- new-deployment-tool-deploy-run-output -->
-          ## New deployment tool results
-          Running deployment...refresh webpage to see results when done. 
+          <!-- run-${{ github.run_id }} -->
+          ## New deployment tool
+          Running deployments in test mode. Results will appear below. 
+          If this pull request and all of it's parent pull requests are merged using the...
         edit-mode: replace
+
+    # one final time, find the comment id for this run now that a comment has been created or had already existed. 
+    - name: Find pull request comment previously created for this particular run, if there is one.
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: peter-evans/find-comment@v3
+      id: get-comment-id
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: '<!-- run-${{ github.run_id }} -->'
+        token: ${{ inputs.github_token }}  
 
     - name: Run deployment tool 
       # Deno's runtime permissions are a great feature. It would be nice to take advantage of it, however, it may not be possible with future features like running plugins. 
@@ -79,36 +103,29 @@ runs:
       uses: peter-evans/create-or-update-comment@v4
       if: ${{ inputs.make_pull_request_comment == 'true' && steps.deployment.outputs.test_mode_on == 'true' && steps.deployment.outcome != 'success' }}
       with:
-        comment-id: ${{ steps.create-or-update-comment.outputs.comment-id }}
+        comment-id: ${{ steps.get-comment-id.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          <!-- new-deployment-tool-deploy-run-output -->
-          ## New deployment tool results 
-          There was a failure when running the deployment. Check [the logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) to see what went wrong.
-        edit-mode: replace
+          - ...🟩 **${{ inputs.simulated_merge_type }}** 🟩 merge method... ⚠️ There was an error during deployment run. [See logs to learn more and fix the issue](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        edit-mode: append
 
     - name: Pull request comment if there will be a release
       uses: peter-evans/create-or-update-comment@v4
       if: ${{ inputs.make_pull_request_comment == 'true' && steps.deployment.outputs.test_mode_on == 'true' && steps.deployment.outcome == 'success' && steps.deployment.outputs.new_release_version != '' }}
       with:
-        comment-id: ${{ steps.create-or-update-comment.outputs.comment-id }}
+        comment-id: ${{ steps.get-comment-id.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          <!-- new-deployment-tool-deploy-run-output -->
-          ## New deployment tool results
-          If this pull request and all of it's parent pull requests are merged, a new release will be created.
-          The next version of the project will be: ${{ steps.deployment.outputs.new_release_version }}
-        edit-mode: replace
+          - ...🟩 **${{ inputs.simulated_merge_type }}** 🟩 merge method... 🚢 The next version of the project will be: **${{ steps.deployment.outputs.new_release_version }}**
+        edit-mode: append 
 
     - name: Pull request comment if there will not be a release
       uses: peter-evans/create-or-update-comment@v4
       if: ${{ inputs.make_pull_request_comment == 'true' && steps.deployment.outputs.test_mode_on == 'true' && steps.deployment.outcome == 'success' && steps.deployment.outputs.new_release_version == '' }}
       with:
-        comment-id: ${{ steps.create-or-update-comment.outputs.comment-id }}
+        comment-id: ${{ steps.get-comment-id.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          <!-- new-deployment-tool-deploy-run-output -->
-          ## New deployment tool results
-          This pull request and all of it's parent pull requests do not have any changes that would trigger a new release.          
-        edit-mode: replace
+          - ...🟩 **${{ inputs.simulated_merge_type }}** 🟩 merge method... 🌴 It will not trigger a deployment. No new version will be deployed.
+        edit-mode: append 
 

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Install Deno runtime to run the CLI
       uses: denoland/setup-deno@v1
       with:
-        deno-version: v2.x
+        deno-version: v2.2
 
     - name: Compile the CLI
       run: deno task compile


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

2 problems we are solving: 
1. **Testing multiple merge types at once** - Example: If you want to test what would happen if you squashed a PR or rebased a PR, you currently can't do that. 
2. **Explain better what the simulated merge result is** - The quality of the comment messages could be better to explain to you that the result is linked to a specific simulated merge type. Right now it's just generic and says, *if you merge, this is next version*, but it doesn't tell you if you squash and merge, rebase, etc. Could result in unexpected consequences from user. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

For now, use a simple solution of modifying just the action.yml code that we currently use for making comments on the pull request. 

1. Re-use 1 comment with all results of simulated merges, if there are multiple. 
2. Update copy of comment to better explain the results. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

Testing in this PR 😄 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->