### PR TITLE
build: fix alpha releases not being marked as latest.

### DIFF
--- a/steps/deploy.ts
+++ b/steps/deploy.ts
@@ -58,8 +58,6 @@ await $`git add action.yml && git commit -m "Bump version to ${input.nextVersion
 console.log(`to help with debugging, log the recently created commit including all the file changes made`)
 await $`git show HEAD`.printCommand()
 
-// if there is a hyphen in the version name, we can assume it's a pre-release version since prod versions do not have hyphens
-const isPreRelease = input.nextVersionName.includes("-")
 const latestGitCommitSha = (await $`git rev-parse HEAD`.text()).trim()
 
 const argsToCreateGithubRelease = [
@@ -67,7 +65,7 @@ const argsToCreateGithubRelease = [
   `create`,
   input.nextVersionName,
   `--generate-notes`,
-  isPreRelease ? "--prerelease" : "",
+  `--latest`,
   `--target`,
   latestGitCommitSha,
   ...githubReleaseAssets,


### PR DESCRIPTION
in last deployment, I noticed that the github release made was not marked as latest. this is bad since github repos advertise the latest release version on the homepage of the repo. I learned you can't mark a pre-release version as latest. For this repo, we want to always use latest even though we are still in alpha.

## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [ ] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->