### PR TITLE
build: fix get latest release script to get latest release on development branch

### DIFF
--- a/steps/get-latest-release.ts
+++ b/steps/get-latest-release.ts
@@ -14,14 +14,35 @@
 
 import { GetLatestReleaseStepOutput } from "../lib/steps/types/output.ts"
 import $ from "@david/dax"
+import { GetLatestReleaseStepInput } from "../lib/types/environment.ts"
+import { git } from "../lib/git.ts"
+import { exec } from "../lib/exec.ts"
 
-const latestReleaseTagName = await $`gh release list --exclude-drafts --order desc --json name,isLatest,isPrerelease,tagName --jq '.[0].tagName'`
+const input: GetLatestReleaseStepInput = JSON.parse(await Deno.readTextFile(Deno.env.get("DATA_FILE_PATH")!))
+
+// First, get the latest release version.
+const latestReleaseVersionName = await $`gh release list --exclude-drafts --order desc --json name,isLatest,isPrerelease,tagName --jq '.[0].name'`
   .text()
-const commitSha = await $`gh release view ${latestReleaseTagName} --json name,tagName,targetCommitish --jq '.targetCommitish'`.text()
+
+if (latestReleaseVersionName.trim() === "") {
+  Deno.exit(0) // No releases found, exit early without writing output.
+}
+
+// Next, get the commit of the latest release. We can't get this from the 'latest' branch because it points to the metadata commit of the latest release, which is not present in the development branch that we are checked out to. Instead, we find the latest commit that is present on both branches.
+const commitsForLatestBranch = await git.getCommits({ exec, branch: "latest" })
+const commitsForCurrentBranch = await git.getCommits({ exec, branch: input.gitCurrentBranch })
+
+const latestCommitOnBothBranches = commitsForLatestBranch.find((commit) =>
+  commitsForCurrentBranch.some((currentCommit) => currentCommit.sha === commit.sha)
+)
+
+if (!latestCommitOnBothBranches) {
+  Deno.exit(0) // No commits found that are present on both branches, exit early without writing output.
+}
 
 const output: GetLatestReleaseStepOutput = {
-  versionName: latestReleaseTagName,
-  commitSha,
+  versionName: latestReleaseVersionName,
+  commitSha: latestCommitOnBothBranches.sha,
 }
 
 await Deno.writeTextFile(Deno.env.get("DATA_FILE_PATH")!, JSON.stringify(output))


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

I noticed in the latest PR, the simulated merge showed me unexpected results. This is because of the fact that we use a `latest` and a trunk branch (`alpha`). The latest release commit is currently retrieved from `latest` branch but that commit doe not exist on the `alpha` branch! 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Find the latest commit that is present on both `latest` and trunk branch. We are looking for commits that are new on trunk since the last deployment so this should work. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

Simulated merge on CI. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->