### PR TITLE
fix: hide github actions debug logs for non-github action environments

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -13,6 +13,7 @@ export const processCommandLineArgs = (cmdArgs: string[]) => {
       "output_file",
       "make_pull_request_comment",
       "fail_on_deploy_verification",
+      "debug",
     ],
     default: {
       github_token: "",
@@ -24,6 +25,7 @@ export const processCommandLineArgs = (cmdArgs: string[]) => {
       output_file: "",
       make_pull_request_comment: "true",
       fail_on_deploy_verification: "true",
+      debug: "false",
     },
   })
 
@@ -37,4 +39,5 @@ export const processCommandLineArgs = (cmdArgs: string[]) => {
   Deno.env.set("INPUT_OUTPUT_FILE", args.output_file)
   Deno.env.set("INPUT_MAKE_PULL_REQUEST_COMMENT", args.make_pull_request_comment)
   Deno.env.set("INPUT_FAIL_ON_DEPLOY_VERIFICATION", args.fail_on_deploy_verification)
+  Deno.env.set("INPUT_DEBUG", args.debug)
 }


### PR DESCRIPTION


## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

If you run the CLI not on GitHub Actions, you will see tons of logs. And that's because we always log debug logs because we're assuming you're on GitHub Actions. 

![CleanShot 2025-07-03 at 07 53 02](https://github.com/user-attachments/assets/b3f563c0-e124-44c1-8977-0d9935367680)


## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

We detect if you are running on GitHub Actions or not in the logger. If you are, everything is going to work like it does today. Otherwise, we hide debug logs unless you pass in a debug command line argument flag. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->